### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,5 @@
 idf_component_register(
     SRCS bmx280.c
     INCLUDE_DIRS "include"
+    REQUIRES driver
 )


### PR DESCRIPTION
Added component REQUIRES driver

This component failed to build for me, can't find "driver/i2c.h". using IDF 5.0

This fixed it.