### PR TITLE
Expose reset function for external use

### DIFF
--- a/bmx280.c
+++ b/bmx280.c
@@ -338,12 +338,6 @@ static esp_err_t bmx280_probe(bmx280_t *bmx280)
     #endif
 }
 
-static esp_err_t bmx280_reset(bmx280_t *bmx280)
-{
-    const static uint8_t din[] = { BMX280_RESET_VEC };
-    return bmx280_write(bmx280, BMX280_REG_RESET, din, sizeof din);
-}
-
 static esp_err_t bmx280_calibrate(bmx280_t *bmx280)
 {
     // Honestly, the best course of action is to read the high and low banks
@@ -447,6 +441,12 @@ bmx280_t* bmx280_create_master(i2c_master_bus_handle_t bus_handle)
     return bmx280;
 }
 #endif
+
+esp_err_t bmx280_reset(bmx280_t *bmx280)
+{
+    const static uint8_t din[] = { BMX280_RESET_VEC };
+    return bmx280_write(bmx280, BMX280_REG_RESET, din, sizeof din);
+}
 
 void bmx280_close(bmx280_t *bmx280)
 {

--- a/include/bmx280.h
+++ b/include/bmx280.h
@@ -58,6 +58,12 @@ BMXAPI bmx280_t* bmx280_create_legacy(i2c_port_t port);
 #endif
 
 /**
+ * Restart the sensor, effectively puting it into sleep mode.
+ * @param bmx280 The instance to reset.
+ */
+esp_err_t bmx280_reset(bmx280_t *bmx280);
+
+/**
  * Destroy your the instance.
  * @param bmx280 The instance to destroy.
  */


### PR DESCRIPTION
The `bmx_reset` function is necessary to put the sensor to sleep and save a few uA.
This PR simply exposes the `bmx_reset` in the library header, so it can be called from outside the library.