### PR TITLE
Increase CMake version requirement to fix compilation on recent CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.17)
 set(CMAKE_C_STANDARD 11)
 idf_component_register(
     SRCS bmx280.c


### PR DESCRIPTION
My system got its CMake binary updated recently to v4.0, which refuses to compile projects requesting a CMake version <3.5

This library currently requires Cmake > 3.1, but 3.1 is already 10 years old (and 3.5 is 9 years old). This PR pushes the version requirement to > 3.17, which was released 5 years ago (https://gitlab.kitware.com/cmake/cmake/-/tags?page=10)
Anything equal or above 3.5 would suit me, but I don't think there's an inconvenient in pushing it a little bit more so we don't have to care about it for at least 5 more years.

Related discussion: https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487