### PR TITLE
Bug fixes for IIR filtering and xlsb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.17)
 set(CMAKE_C_STANDARD 11)
 idf_component_register(
     SRCS bmx280.c

--- a/bmx280.c
+++ b/bmx280.c
@@ -634,7 +634,7 @@ esp_err_t bmx280_readout(bmx280_t *bmx280, int32_t *temperature, uint32_t *press
             return error;
 
         *temperature = BME280_compensate_T_int32(bmx280,
-                        (buffer[0] << 12) | (buffer[1] << 4) | (buffer[0] >> 4)
+                        (buffer[0] << 12) | (buffer[1] << 4) | (buffer[2] >> 4)
                     );
     }
 
@@ -644,7 +644,7 @@ esp_err_t bmx280_readout(bmx280_t *bmx280, int32_t *temperature, uint32_t *press
             return error;
 
         *pressure = BME280_compensate_P_int64(bmx280, 
-                        (buffer[0] << 12) | (buffer[1] << 4) | (buffer[0] >> 4)
+                        (buffer[0] << 12) | (buffer[1] << 4) | (buffer[2] >> 4)
                     );
     }
 

--- a/include/bmx280_bits.h
+++ b/include/bmx280_bits.h
@@ -57,7 +57,6 @@ typedef enum bmx280_tstby_t {
 
 typedef enum bmx280_iirf_t {
     BMX280_IIR_NONE = 0x0,
-    BMX280_IIR_X1,
     BMX280_IIR_X2,
     BMX280_IIR_X4,
     BMX280_IIR_X8,


### PR DESCRIPTION
This PR is built on top of https://github.com/utkumaden/esp-idf-bmx280/pull/8
The `xlsb` part of the pressure and temperature buffers wasn't used, leading to loss of precision and incorrect values, and a non-existent filter was available, leading to incorrect labeling of filters.